### PR TITLE
Fix crash on close when deleting the wdfTree in MainComponent dtor

### DIFF
--- a/Libs/rt-wdf/rt-wdf.cpp
+++ b/Libs/rt-wdf/rt-wdf.cpp
@@ -279,7 +279,7 @@ wdfTreeNode::wdfTreeNode( std::vector<wdfTreeNode*> childrenIn ) {
 //----------------------------------------------------------------------
 void wdfTreeNode::setParentInChildren( ) {
     for (wdfTreeNode* child : childrenNodes) {
-        child->parentNode.reset( this );
+        child->parentNode = this ;
         child->setParentInChildren( );
     }
 }
@@ -288,7 +288,7 @@ void wdfTreeNode::setParentInChildren( ) {
 void wdfTreeNode::createPorts( ) {
     for( unsigned int i = 0; i < childrenNodes.size(); i++) {
         downPorts.push_back( new wdfPort( childrenNodes[i] ) );
-        childrenNodes[i]->upPort->connectedNode.reset( this );
+        childrenNodes[i]->upPort->connectedNode = this;
         childrenNodes[i]->createPorts( );
     }
 }

--- a/Libs/rt-wdf/rt-wdf.h
+++ b/Libs/rt-wdf/rt-wdf.h
@@ -84,7 +84,7 @@ class wdfRootNode;
 //==============================================================================
 class wdfTree {
 
-protected:
+public:
     //----------------------------------------------------------------------
     /**
      Base class for a WDF tree.
@@ -102,6 +102,7 @@ protected:
      */
     virtual ~wdfTree( );
 
+protected:
     //----------------------------------------------------------------------
     /**
      Pointer to the root object of this tree.
@@ -536,7 +537,7 @@ private:
     /**
      Pointer to a single unadapted root element.
      */
-    std::unique_ptr<wdfRootNode> rootElement;
+    wdfRootNode* rootElement;
 
 public:
     //----------------------------------------------------------------------
@@ -646,7 +647,7 @@ public:
     /**
      Pointer to the node that connects to that port.
      */
-    std::unique_ptr<wdfTreeNode> connectedNode;
+    wdfTreeNode* connectedNode;
 
 };
 
@@ -831,7 +832,7 @@ public:
     /**
      Pointer to the connected parent node of this node.
      */
-    std::unique_ptr<wdfTreeNode> parentNode;
+    wdfTreeNode* parentNode;
 
 protected:
     //----------------------------------------------------------------------
@@ -1262,7 +1263,7 @@ public:
      port and non-implicit behaviour.
      */
     wdfTerminatedLeaf();
-
+    
     //----------------------------------------------------------------------
     /**
      This variant of the base classes' calculateScatterCoeffs() function

--- a/wdfRenderer/JUCE/wdfRenderer/Source/MainComponent.cpp
+++ b/wdfRenderer/JUCE/wdfRenderer/Source/MainComponent.cpp
@@ -116,7 +116,7 @@ public:
         for (Component* comp : paramLabels) {
             delete comp;
         }
-
+        delete myWdfTree;
     }
 
     void writeLogLine (String logLine) {


### PR DESCRIPTION
Since the nodes are owned by the examples classes (wdfTonestackTree, wdfSwitchTree...) you should only have raw pointer in your wdfTreeNode and wdfPort classes