### PR TITLE
Fixes related to port resistances, setting member variables

### DIFF
--- a/Libs/rt-wdf/rt-wdf.cpp
+++ b/Libs/rt-wdf/rt-wdf.cpp
@@ -557,7 +557,7 @@ wdfTerminatedCap::wdfTerminatedCap( double C,
 
 //----------------------------------------------------------------------
 double wdfTerminatedCap::calculateUpRes( double T ) {
-    T = T;
+    this->T = T;
     const double R = T / ( 2.0 * C );
     return R;
 }
@@ -589,7 +589,7 @@ wdfTerminatedInd::wdfTerminatedInd( double L,
 
 //----------------------------------------------------------------------
 double wdfTerminatedInd::calculateUpRes( double T ) {
-    T = T;
+    this->T = T;
     const double R = ( 2.0 * L ) / T;
     return R;
 }
@@ -671,7 +671,7 @@ std::string wdfTerminatedResVSource::getType( ) const {
 //                             R O O T   N O D E
 //==============================================================================
 wdfRootNode::wdfRootNode( int numPorts ) {
-    numPorts = numPorts;
+    this->numPorts = numPorts;
 }
 //----------------------------------------------------------------------
 wdfRootNode::~wdfRootNode( ) {
@@ -680,7 +680,7 @@ wdfRootNode::~wdfRootNode( ) {
 
 //----------------------------------------------------------------------
 void wdfRootNode::setPortResistance( double Rp ) {
-    Rp = Rp;
+    this->Rp = Rp;
 }
 
 int wdfRootNode::getNumPorts( ){
@@ -751,7 +751,7 @@ std::string wdfUnterminatedCap::getType( ) const {
 }
 
 void wdfUnterminatedCap::setPortResistance( double Rp ) {
-    Rp = Rp;
+    this->Rp = Rp;
     reflectionCoeff = (Rp - T / (2 * C)) / (Rp + (T / (2 * C)));
 }
 
@@ -783,7 +783,7 @@ std::string wdfUnterminatedInd::getType( ) const {
 }
 
 void wdfUnterminatedInd::setPortResistance( double Rp ) {
-    Rp = Rp;
+    this->Rp = Rp;
     reflectionCoeff = (Rp - 2 * L/T) / (Rp + 2 * L/T);
 }
 
@@ -809,7 +809,7 @@ std::string wdfUnterminatedRes::getType( ) const {
 }
 
 void wdfUnterminatedRes::setPortResistance( double Rp ) {
-    Rp = Rp;
+    this->Rp = Rp;
     reflectionCoeff = (R - Rp) / (R + Rp);
 }
 
@@ -836,7 +836,7 @@ std::string wdfIdealVSource::getType( ) const {
 
 //----------------------------------------------------------------------
 void wdfIdealVSource::setPortResistance( double Rp ) {
-    Rp = Rp;
+    this->Rp = Rp;
 }
 
 #pragma mark Ideal Current Source
@@ -861,6 +861,6 @@ std::string wdfIdealCSource::getType( ) const {
 
 //----------------------------------------------------------------------
 void wdfIdealCSource::setPortResistance( double Rp ) {
-    Rp = Rp;
+    this->Rp = Rp;
 }
 

--- a/Libs/rt-wdf/rt-wdf.h
+++ b/Libs/rt-wdf/rt-wdf.h
@@ -320,7 +320,7 @@ public:
      @param Rp                  is a vector of port resistances of all
                                 subtrees of the root.
      */
-    void setPortResistances( double * Rp );
+    virtual void setPortResistances( double * Rp );
 
     //----------------------------------------------------------------------
     /**
@@ -1794,7 +1794,7 @@ public:
 
      @param Rp                  port resistance in Ohm
      */
-    void setPortResistance( double Rp );
+    virtual void setPortResistance( double Rp );
 
     //----------------------------------------------------------------------
     /**
@@ -1880,7 +1880,7 @@ public:
 
      @param Rp                  port resistance in Ohm
      */
-    void setPortResistance( double Rp );
+    virtual void setPortResistance( double Rp );
 
     //----------------------------------------------------------------------
     /**
@@ -1949,7 +1949,7 @@ public:
 
      @param Rp                  port resistance in Ohm
      */
-    void setPortResistance( double Rp );
+    virtual void setPortResistance( double Rp );
 
     //----------------------------------------------------------------------
     /**
@@ -2004,7 +2004,7 @@ public:
 
      @param Rp                  port resistance in Ohm
      */
-    void setPortResistance( double Rp );
+    virtual void setPortResistance( double Rp );
 
     //----------------------------------------------------------------------
     /**
@@ -2059,7 +2059,7 @@ public:
 
      @param Rp                  port resistance in Ohm
      */
-    void setPortResistance( double Rp );
+    virtual void setPortResistance( double Rp );
 
     //----------------------------------------------------------------------
     /**


### PR DESCRIPTION
Some of these changes may have been provided privately, but I spotted some others that may not have been included.

This addresses some issues I encountered, namely:
* The port resistance for some type of root nodes was not being set because the method was not marked virtual
* A number of assignments  were assigning a local to itself, rather than to a member variable.