### PR TITLE
Reactive elements alpha transform

### DIFF
--- a/Libs/rt-wdf/rt-wdf.cpp
+++ b/Libs/rt-wdf/rt-wdf.cpp
@@ -548,17 +548,18 @@ void wdfTerminatedLeaf::calculateScatterCoeffs( ) {
 #pragma mark Terminated Capacitor
 //==============================================================================
 wdfTerminatedCap::wdfTerminatedCap( double C,
-                                    double T ) : wdfTerminatedLeaf( ),
+                                    double T,
+                                    double alpha = 1 ) : wdfTerminatedLeaf( ),
                                                  C( C ),
                                                  T( T ),
+                                                 alpha( alpha ),
                                                  prevA( 0 ) {
-
 }
 
 //----------------------------------------------------------------------
 double wdfTerminatedCap::calculateUpRes( double T ) {
     this->T = T;
-    const double R = T / ( 2.0 * C );
+    const double R = T / ( (1.0 + alpha) * C );
     return R;
 }
 
@@ -580,9 +581,11 @@ std::string wdfTerminatedCap::getType( ) const {
 #pragma mark Terminated Inductor
 //==============================================================================
 wdfTerminatedInd::wdfTerminatedInd( double L,
-                                    double T ) : wdfTerminatedLeaf( ),
+                                    double T,
+                                    double alpha = 1.0 ) : wdfTerminatedLeaf( ),
                                                  L( L ),
                                                  T( T ),
+                                                 alpha( alpha ),
                                                  prevA( 0 ) {
 
 }
@@ -590,7 +593,7 @@ wdfTerminatedInd::wdfTerminatedInd( double L,
 //----------------------------------------------------------------------
 double wdfTerminatedInd::calculateUpRes( double T ) {
     this->T = T;
-    const double R = ( 2.0 * L ) / T;
+    const double R = ( (1 + alpha) * L ) / T;
     return R;
 }
 
@@ -754,8 +757,10 @@ std::string wdfUnterminatedSwitch::getType( ) const {
 #pragma mark Unterminated Capacitor
 //==============================================================================
 wdfUnterminatedCap::wdfUnterminatedCap(double C,
-                                       double T ) : wdfRootNode(1),
+                                       double T,
+                                       double alpha = 1.0 ) : wdfRootNode(1),
                                                     T(T),
+                                                    alpha(alpha),
                                                     prevA(0),
                                                     prevB(0),
                                                     C(C) {
@@ -780,14 +785,16 @@ std::string wdfUnterminatedCap::getType( ) const {
 
 void wdfUnterminatedCap::setPortResistance( double Rp ) {
     this->Rp = Rp;
-    reflectionCoeff = (Rp - T / (2 * C)) / (Rp + (T / (2 * C)));
+    reflectionCoeff = (Rp - T / ((1 + alpha) * C)) / (Rp + (T / ((1 + alpha) * C)));
 }
 
 #pragma mark Unterminated Inductor
 //==============================================================================
 wdfUnterminatedInd::wdfUnterminatedInd( double L,
-                                        double T ) : wdfRootNode(1),
+                                        double T,
+                                        double alpha ) : wdfRootNode(1),
                                                      T(T),
+                                                     alpha(alpha),
                                                      prevA(0),
                                                      prevB(0),
                                                      L(L) {
@@ -812,7 +819,7 @@ std::string wdfUnterminatedInd::getType( ) const {
 
 void wdfUnterminatedInd::setPortResistance( double Rp ) {
     this->Rp = Rp;
-    reflectionCoeff = (Rp - 2 * L/T) / (Rp + 2 * L/T);
+    reflectionCoeff = (Rp - (1 + alpha) * L/T) / (Rp + (1 + alpha) * L/T);
 }
 
 

--- a/Libs/rt-wdf/rt-wdf.cpp
+++ b/Libs/rt-wdf/rt-wdf.cpp
@@ -231,7 +231,6 @@ std::string wdfRootSimple::getType( ) const {
 //                                  P O R T
 //==============================================================================
 wdfPort::wdfPort( wdfTreeNode *connectedNode ) : Rp( 0 ),
-                                                 Gp( 0 ),
                                                  a( 0 ),
                                                  b( 0 ),
                                                  connectedNode( connectedNode ) {

--- a/Libs/rt-wdf/rt-wdf.cpp
+++ b/Libs/rt-wdf/rt-wdf.cpp
@@ -549,7 +549,7 @@ void wdfTerminatedLeaf::calculateScatterCoeffs( ) {
 //==============================================================================
 wdfTerminatedCap::wdfTerminatedCap( double C,
                                     double T,
-                                    double alpha = 1 ) : wdfTerminatedLeaf( ),
+                                    double alpha) : wdfTerminatedLeaf( ),
                                                  C( C ),
                                                  T( T ),
                                                  alpha( alpha ),
@@ -582,7 +582,7 @@ std::string wdfTerminatedCap::getType( ) const {
 //==============================================================================
 wdfTerminatedInd::wdfTerminatedInd( double L,
                                     double T,
-                                    double alpha = 1.0 ) : wdfTerminatedLeaf( ),
+                                    double alpha ) : wdfTerminatedLeaf( ),
                                                  L( L ),
                                                  T( T ),
                                                  alpha( alpha ),
@@ -593,7 +593,7 @@ wdfTerminatedInd::wdfTerminatedInd( double L,
 //----------------------------------------------------------------------
 double wdfTerminatedInd::calculateUpRes( double T ) {
     this->T = T;
-    const double R = ( (1 + alpha) * L ) / T;
+    const double R = ( (1.0 + alpha) * L ) / T;
     return R;
 }
 
@@ -758,7 +758,7 @@ std::string wdfUnterminatedSwitch::getType( ) const {
 //==============================================================================
 wdfUnterminatedCap::wdfUnterminatedCap(double C,
                                        double T,
-                                       double alpha = 1.0 ) : wdfRootNode(1),
+                                       double alpha ) : wdfRootNode(1),
                                                     T(T),
                                                     alpha(alpha),
                                                     prevA(0),
@@ -785,7 +785,7 @@ std::string wdfUnterminatedCap::getType( ) const {
 
 void wdfUnterminatedCap::setPortResistance( double Rp ) {
     this->Rp = Rp;
-    reflectionCoeff = (Rp - T / ((1 + alpha) * C)) / (Rp + (T / ((1 + alpha) * C)));
+    reflectionCoeff = (Rp - T / ((1.0 + alpha) * C)) / (Rp + (T / ((1.0 + alpha) * C)));
 }
 
 #pragma mark Unterminated Inductor
@@ -819,7 +819,7 @@ std::string wdfUnterminatedInd::getType( ) const {
 
 void wdfUnterminatedInd::setPortResistance( double Rp ) {
     this->Rp = Rp;
-    reflectionCoeff = (Rp - (1 + alpha) * L/T) / (Rp + (1 + alpha) * L/T);
+    reflectionCoeff = (Rp - (1.0 + alpha) * L/T) / (Rp + (1.0 + alpha) * L/T);
 }
 
 

--- a/Libs/rt-wdf/rt-wdf.h
+++ b/Libs/rt-wdf/rt-wdf.h
@@ -1286,7 +1286,7 @@ public:
      */
     wdfTerminatedCap( double C,
                       double T,
-                      double alpha);
+                      double alpha = 1.0 );
 
     //----------------------------------------------------------------------
     /**
@@ -1374,7 +1374,7 @@ public:
      */
     wdfTerminatedInd( double L,
                       double T,
-                      double alpha );
+                      double alpha = 1.0 );
 
     //----------------------------------------------------------------------
     /**
@@ -1854,7 +1854,7 @@ public:
     */
     wdfUnterminatedCap( double C,
                         double T,
-                        double alpha );
+                        double alpha = 1.0 );
 
     //----------------------------------------------------------------------
     /**
@@ -1950,7 +1950,7 @@ public:
     */
     wdfUnterminatedInd( double L,
                         double T,
-                        double alpha );
+                        double alpha = 1.0 );
 
     //----------------------------------------------------------------------
     /**

--- a/Libs/rt-wdf/rt-wdf.h
+++ b/Libs/rt-wdf/rt-wdf.h
@@ -1281,9 +1281,12 @@ public:
 
      @param C                  physical capacitance of the component in Farads
      @param T                  sample period T = 1/fs in seconds
+     @param alpha              parameter in alpha transform, default = 1.0
+                               (Bilinear transform)
      */
     wdfTerminatedCap( double C,
-                      double T );
+                      double T,
+                      double alpha);
 
     //----------------------------------------------------------------------
     /**
@@ -1343,6 +1346,11 @@ public:
      */
     double T;
     /**
+     Paramter for alpha transform
+     */
+    double alpha;
+
+    /**
      One sample delay element
      */
     double prevA;
@@ -1361,9 +1369,12 @@ public:
 
      @param L                  physical inductance of the component in Henry
      @param T                  sample period T = 1/fs in seconds
+     @param alpha              parameter in alpha transform, default = 1.0
+                               (Bilinear transform)
      */
     wdfTerminatedInd( double L,
-                      double T );
+                      double T,
+                      double alpha );
 
     //----------------------------------------------------------------------
     /**
@@ -1423,6 +1434,10 @@ public:
      Sample period in seconds
      */
     double T;
+    /**
+     Parameter in alpha-transform
+    */
+    double alpha;
     /**
      One sample delay element
      */
@@ -1834,9 +1849,12 @@ public:
 
      @param C                  physical capacitance of the component in Farads
      @param T                  sample period T = 1/fs in seconds
+     @param alpha              parameter in alpha transform, default = 1.0
+                               (Bilinear transform)
     */
     wdfUnterminatedCap( double C,
-                        double T );
+                        double T,
+                        double alpha );
 
     //----------------------------------------------------------------------
     /**
@@ -1886,6 +1904,11 @@ public:
     */
     double C;
 
+    //----------------------------------------------------------------------
+    /**
+     Parameter in alpha-transform
+    */
+    double alpha;
 };
 
 //==============================================================================
@@ -1922,9 +1945,12 @@ public:
 
      @param L                  physical inductance of the component in Henry
      @param T                  sample period T = 1/fs in seconds
+     @param alpha              parameter in alpha transform, default = 1.0
+                               (Bilinear transform)
     */
     wdfUnterminatedInd( double L,
-                        double T );
+                        double T,
+                        double alpha );
 
     //----------------------------------------------------------------------
     /**
@@ -1971,6 +1997,11 @@ public:
      Inductance in Henry
     */
     double L;
+    //----------------------------------------------------------------------
+    /**
+     Parameter in alpha-transform
+    */
+    double alpha;
 
 };
 

--- a/Libs/rt-wdf/rt-wdf.h
+++ b/Libs/rt-wdf/rt-wdf.h
@@ -627,12 +627,6 @@ public:
 
     //----------------------------------------------------------------------
     /**
-     The inverse WDF port resistance in Siemens
-     */
-    double Gp;
-
-    //----------------------------------------------------------------------
-    /**
      Incident wave (incoming wave)
      */
     double a;
@@ -1272,6 +1266,26 @@ public:
 //==============================================================================
 class wdfTerminatedCap : public wdfTerminatedLeaf {
 
+protected:
+    //----------------------------------------------------------------------
+    /**
+     Capacitance in Farad
+     */
+    double C;
+    /**
+     Sample period in seconds
+     */
+    double T;
+    /**
+     Paramter for alpha transform
+     */
+    double alpha;
+
+    /**
+     One sample delay element
+     */
+    double prevA;
+    
 public:
     //----------------------------------------------------------------------
     /**
@@ -1335,25 +1349,6 @@ public:
                                 "C (adapted)"
      */
     virtual std::string getType( ) const;
-
-    //----------------------------------------------------------------------
-    /**
-     Capacitance in Farad
-     */
-    double C;
-    /**
-     Sample period in seconds
-     */
-    double T;
-    /**
-     Paramter for alpha transform
-     */
-    double alpha;
-
-    /**
-     One sample delay element
-     */
-    double prevA;
 
 };
 

--- a/Libs/rt-wdf/rt-wdf.h
+++ b/Libs/rt-wdf/rt-wdf.h
@@ -139,12 +139,6 @@ protected:
 
     //----------------------------------------------------------------------
     /**
-     Inverse of treeSampleRate
-     */
-    double T;
-
-    //----------------------------------------------------------------------
-    /**
      Number of subtrees
      */
     size_t subtreeCount;
@@ -196,8 +190,8 @@ public:
     /**
      High level function to adapt all ports in subtrees.
 
-     Recursively adapts all subtrees towards the root according to sample
-     period T. Updates root matrix data afterwards if applicable to take
+     Recursively adapts all subtrees towards the root according to sampleRate.
+     Updates root matrix data afterwards if applicable to take
      new port resistances into account.
      */
     int adaptTree( );
@@ -723,11 +717,11 @@ public:
      and/or adaptation rules and copies it onto connected downfacing ports
      in the parent.
 
-     @param T                   sample period as specified by setSamplerate()
+     @param sampleRate          sample rate as specified by setSamplerate()
      @returns                   a double type up-facing port resistance of that
                                 WDF element
      */
-    double adaptPorts( double T );
+    double adaptPorts( double sampleRate );
 
     //----------------------------------------------------------------------
     /**
@@ -738,12 +732,12 @@ public:
      port resistance of a tree node to fulfill adaptation according to
      the respective adaptation law of this node.
 
-     @param T                   sample period T = 1/fs as needed to adapt
+     @param sampleRate          sample rate as needed to adapt 
                                 capacitors/inductors
      @returns                   a double type port resistance of that element
                                 in Ohms
      */
-    virtual double calculateUpRes( double T ) = 0;
+    virtual double calculateUpRes( double sampleRate ) = 0;
 
     //----------------------------------------------------------------------
     /**
@@ -909,12 +903,12 @@ public:
      Must be implemented in the user-defined subclass of wdfTerminatedRtype in
      the WDF application tree.
 
-     @param T                   sample period T = 1/fs as needed to adapt
+     @param sampleRate          sample rate as needed to adapt
                                 capacitors/inductors
      @returns                   a double type port resistance of that element
                                 in Ohms
      */
-    virtual double calculateUpRes( double T ) = 0;
+    virtual double calculateUpRes( double sampleRate ) = 0;
 
     //----------------------------------------------------------------------
     /**
@@ -1016,12 +1010,12 @@ public:
      port resistance of the node to fulfill termination according to
      the series adaptation law Rup = Rleft + Rright.
 
-     @param T                   sample period T = 1/fs as needed to adapt
+     @param sampleRate          sample rate as needed to adapt
                                 capacitors/inductors
      @returns                   a double type port resistance of that element
                                 in Ohms
      */
-    virtual double calculateUpRes( double T );
+    virtual double calculateUpRes( double sampleRate );
 
     //----------------------------------------------------------------------
     /**
@@ -1109,12 +1103,12 @@ public:
      port resistance of the node to fulfill termination according to
      the series adaptation law Gup = Gleft + Gright.
 
-     @param T                   sample period T = 1/fs as needed to adapt
+     @param sampleRate          sample rate as needed to adapt
                                 capacitors/inductors
      @returns                   a double type port resistance of that element
                                 in Ohms
      */
-    virtual double calculateUpRes( double T );
+    virtual double calculateUpRes( double sampleRate );
 
     //----------------------------------------------------------------------
     /**
@@ -1184,12 +1178,12 @@ public:
      port resistance of the node to fulfill termination according to
      the inverters adaptation law Rup = Rchild.
 
-     @param T                   sample period T = 1/fs as needed to adapt
+     @param sampleRate          sample rate as needed to adapt
                                 capacitors/inductors
      @returns                   a double type port resistance of that element
                                 in Ohms
      */
-    virtual double calculateUpRes( double T );
+    virtual double calculateUpRes( double sampleRate );
 
     //----------------------------------------------------------------------
     /**
@@ -1273,9 +1267,9 @@ protected:
      */
     double C;
     /**
-     Sample period in seconds
+     Sample rate in Hertz
      */
-    double T;
+    double sampleRate;
     /**
      Paramter for alpha transform
      */
@@ -1294,12 +1288,12 @@ public:
      Creates a capacitor with capacitance C.
 
      @param C                  physical capacitance of the component in Farads
-     @param T                  sample period T = 1/fs in seconds
+     @param sampleRate         sample rate in Hertz
      @param alpha              parameter in alpha transform, default = 1.0
                                (Bilinear transform)
      */
     wdfTerminatedCap( double C,
-                      double T,
+                      double sampleRate,
                       double alpha = 1.0 );
 
     //----------------------------------------------------------------------
@@ -1308,14 +1302,14 @@ public:
 
      This function is called from adaptPorts(). It returns the upfacing
      port resistance of the node to fulfill termination according to
-     the capacitors adaptation law Rup = T / ( 2.0 * C ).
+     the capacitors adaptation law Rup = 1 / ( 2.0 * sampleRate * C ).
 
-     @param T                   sample period T = 1/fs in seconds as needed to
+     @param sampleRate          sample rate in Hertz as needed to
                                 adapt the capacitor
      @returns                   a double type port resistance of that element
                                 in Ohms
      */
-    virtual double calculateUpRes( double T );
+    virtual double calculateUpRes( double sampleRate );
 
     //----------------------------------------------------------------------
     /**
@@ -1363,12 +1357,12 @@ public:
      Creates an inductor with inductance L.
 
      @param L                  physical inductance of the component in Henry
-     @param T                  sample period T = 1/fs in seconds
+     @param sampleRate         sample rate in Hertz
      @param alpha              parameter in alpha transform, default = 1.0
                                (Bilinear transform)
      */
     wdfTerminatedInd( double L,
-                      double T,
+                      double sampleRate,
                       double alpha = 1.0 );
 
     //----------------------------------------------------------------------
@@ -1377,14 +1371,14 @@ public:
 
      This function is called from adaptPorts(). It returns the upfacing
      port resistance of the node to fulfill termination according to
-     the inverters adaptation law Rup = R = ( 2.0 * L ) / T.
+     the inverters adaptation law Rup = R = 2.0 * sampleRate L.
 
-     @param T                   sample period T = 1/fs in seconds as needed to
+     @param sampleRate          sample rate in Hertz as needed to
                                 adapt the capacitor
      @returns                   a double type port resistance of that element
                                 in Ohms
      */
-    virtual double calculateUpRes( double T );
+    virtual double calculateUpRes( double sampleRate );
 
     //----------------------------------------------------------------------
     /**
@@ -1426,9 +1420,9 @@ public:
      */
     double L;
     /**
-     Sample period in seconds
+     Sample rate in Hertz
      */
-    double T;
+    double sampleRate;
     /**
      Parameter in alpha-transform
     */
@@ -1462,12 +1456,12 @@ public:
      port resistance of the node to fulfill termination according to
      the resistors adaptation law Rup = R.
 
-     @param T                   sample period T = 1/fs in seconds as needed to
+     @param sampleRate          sample rate in Hertz as needed to
                                 adapt the capacitor
      @returns                   a double type port resistance of that element
                                 in Ohms
      */
-    virtual double calculateUpRes( double T );
+    virtual double calculateUpRes( double sampleRate );
 
     //----------------------------------------------------------------------
     /**
@@ -1534,12 +1528,12 @@ public:
      port resistance of the node to fulfill termination according to
      the adaptation law Rup = Rser.
 
-     @param T                   sample period T = 1/fs in seconds as needed to
+     @param sampleRate          sample rate in Hertz as needed to
                                 adapt the capacitor
      @returns                   a double type port resistance of that element
                                 in Ohms
      */
-    virtual double calculateUpRes( double T );
+    virtual double calculateUpRes( double sampleRate );
 
     //----------------------------------------------------------------------
     /**
@@ -1611,12 +1605,12 @@ public:
      port resistance of the node to fulfill termination according to
      the adaptation law Rup = Rpar.
 
-     @param T                   sample period T = 1/fs in seconds as needed to
+     @param sampleRate          sample rate in Hertz as needed to
                                 adapt the element
      @returns                   a double type port resistance of that element
                                 in Ohms
      */
-    virtual double calculateUpRes( double T );
+    virtual double calculateUpRes( double sampleRate );
 
     //----------------------------------------------------------------------
     /**
@@ -1816,9 +1810,9 @@ class wdfUnterminatedCap : public wdfRootNode {
 protected:
     //----------------------------------------------------------------------
     /**
-     Sample period in seconds
+     Sample rate in Hertz
     */
-    double T;
+    double sampleRate;
     /**
      Place to store the previous incident wave component.
     */
@@ -1843,12 +1837,12 @@ public:
      Creates an unadapted capacitor with capacitance C.
 
      @param C                  physical capacitance of the component in Farads
-     @param T                  sample period T = 1/fs in seconds
+     @param sampleRate         sample rate in Hertz
      @param alpha              parameter in alpha transform, default = 1.0
                                (Bilinear transform)
     */
     wdfUnterminatedCap( double C,
-                        double T,
+                        double sampleRate,
                         double alpha = 1.0 );
 
     //----------------------------------------------------------------------
@@ -1912,9 +1906,9 @@ class wdfUnterminatedInd : public wdfRootNode {
 protected:
     //----------------------------------------------------------------------
     /**
-     Sample period in seconds
+     Sample rate in Hertz
     */
-    double T;
+    double sampleRate;
     /**
      Place to store the previous incident wave component.
     */
@@ -1939,12 +1933,12 @@ public:
      Creates an unadapted inductor with capacitance L.
 
      @param L                  physical inductance of the component in Henry
-     @param T                  sample period T = 1/fs in seconds
+     @param sampleRate         sample rate in Hertz
      @param alpha              parameter in alpha transform, default = 1.0
                                (Bilinear transform)
     */
     wdfUnterminatedInd( double L,
-                        double T,
+                        double sampleRate,
                         double alpha = 1.0 );
 
     //----------------------------------------------------------------------


### PR DESCRIPTION
Added a parameter associated with the alpha-transform (numerical scheme). Now users can optionally pass in a parameters to each reactive element to choose any alpha transform, e.g., alpha=1.0 is bilinear transform (default value), alpha=0 is backwards Euler.