### PR TITLE
Sample period to sampling rate

### DIFF
--- a/Libs/rt-wdf/rt-wdf.cpp
+++ b/Libs/rt-wdf/rt-wdf.cpp
@@ -28,8 +28,7 @@
 
 //==============================================================================
 #include "rt-wdf.h"
-
-
+#include <assert.h>
 
 #pragma mark - Tree
 //==============================================================================
@@ -461,10 +460,13 @@ wdfTerminatedParallel::wdfTerminatedParallel( wdfTreeNode *left,
 
 //----------------------------------------------------------------------
 double wdfTerminatedParallel::calculateUpRes( double sampleRate ) {
+    assert(Rleft > 0 && "Port resistance must be a nonzero positive number.");
+    assert(Rright > 0 && "Port resistance must be a nonzero positive number.");
+
     const double Rleft  = downPorts[0]->Rp;
     const double Rright = downPorts[1]->Rp;
     const double Rpar   = ( Rleft * Rright ) / ( Rleft + Rright );
-    return ( Rpar );
+    return Rpar;
 }
 
 //----------------------------------------------------------------------
@@ -555,6 +557,9 @@ wdfTerminatedCap::wdfTerminatedCap( double C,
 
 //----------------------------------------------------------------------
 double wdfTerminatedCap::calculateUpRes( double sampleRate ) {
+    assert(sampleRate > 0 && "sampleRate must be a nonzero positive number.");
+    assert(C > 0 && "capacitance must be a nonzero positive number.");
+
     this->sampleRate = sampleRate;
     const double R = 1 / ( 2.0 * sampleRate * C );
     return R;
@@ -587,6 +592,9 @@ wdfTerminatedInd::wdfTerminatedInd( double L,
 
 //----------------------------------------------------------------------
 double wdfTerminatedInd::calculateUpRes( double sampleRate ) {
+    assert(sampleRate > 0 && "sampleRate must be a nonzero positive number.");
+    assert(L > 0 && "inductance must be a nonzero positive number.");
+
     this->sampleRate = sampleRate;
     const double R = 2.0 * sampleRate * L ;
     return R;

--- a/Libs/rt-wdf/rt-wdf.cpp
+++ b/Libs/rt-wdf/rt-wdf.cpp
@@ -460,11 +460,12 @@ wdfTerminatedParallel::wdfTerminatedParallel( wdfTreeNode *left,
 
 //----------------------------------------------------------------------
 double wdfTerminatedParallel::calculateUpRes( double sampleRate ) {
-    assert(Rleft > 0 && "Port resistance must be a nonzero positive number.");
-    assert(Rright > 0 && "Port resistance must be a nonzero positive number.");
-
     const double Rleft  = downPorts[0]->Rp;
     const double Rright = downPorts[1]->Rp;
+
+    assert(Rleft > 0 && "Port resistance must be a nonzero positive number.");
+    assert(Rright > 0 && "Port resistance must be a nonzero positive number.");
+    
     const double Rpar   = ( Rleft * Rright ) / ( Rleft + Rright );
     return Rpar;
 }

--- a/Libs/rt-wdf/rt-wdf.h
+++ b/Libs/rt-wdf/rt-wdf.h
@@ -139,12 +139,6 @@ protected:
 
     //----------------------------------------------------------------------
     /**
-     Inverse of treeSampleRate
-     */
-    double T;
-
-    //----------------------------------------------------------------------
-    /**
      Number of subtrees
      */
     size_t subtreeCount;
@@ -196,8 +190,8 @@ public:
     /**
      High level function to adapt all ports in subtrees.
 
-     Recursively adapts all subtrees towards the root according to sample
-     period T. Updates root matrix data afterwards if applicable to take
+     Recursively adapts all subtrees towards the root according to sampleRate.
+     Updates root matrix data afterwards if applicable to take
      new port resistances into account.
      */
     int adaptTree( );
@@ -729,11 +723,11 @@ public:
      and/or adaptation rules and copies it onto connected downfacing ports
      in the parent.
 
-     @param T                   sample period as specified by setSamplerate()
+     @param sampleRate          sample rate as specified by setSamplerate()
      @returns                   a double type up-facing port resistance of that
                                 WDF element
      */
-    double adaptPorts( double T );
+    double adaptPorts( double sampleRate );
 
     //----------------------------------------------------------------------
     /**
@@ -744,12 +738,12 @@ public:
      port resistance of a tree node to fulfill adaptation according to
      the respective adaptation law of this node.
 
-     @param T                   sample period T = 1/fs as needed to adapt
+     @param sampleRate          sample rate as needed to adapt 
                                 capacitors/inductors
      @returns                   a double type port resistance of that element
                                 in Ohms
      */
-    virtual double calculateUpRes( double T ) = 0;
+    virtual double calculateUpRes( double sampleRate ) = 0;
 
     //----------------------------------------------------------------------
     /**
@@ -915,12 +909,12 @@ public:
      Must be implemented in the user-defined subclass of wdfTerminatedRtype in
      the WDF application tree.
 
-     @param T                   sample period T = 1/fs as needed to adapt
+     @param sampleRate          sample rate as needed to adapt
                                 capacitors/inductors
      @returns                   a double type port resistance of that element
                                 in Ohms
      */
-    virtual double calculateUpRes( double T ) = 0;
+    virtual double calculateUpRes( double sampleRate ) = 0;
 
     //----------------------------------------------------------------------
     /**
@@ -1022,12 +1016,12 @@ public:
      port resistance of the node to fulfill termination according to
      the series adaptation law Rup = Rleft + Rright.
 
-     @param T                   sample period T = 1/fs as needed to adapt
+     @param sampleRate          sample rate as needed to adapt
                                 capacitors/inductors
      @returns                   a double type port resistance of that element
                                 in Ohms
      */
-    virtual double calculateUpRes( double T );
+    virtual double calculateUpRes( double sampleRate );
 
     //----------------------------------------------------------------------
     /**
@@ -1115,12 +1109,12 @@ public:
      port resistance of the node to fulfill termination according to
      the series adaptation law Gup = Gleft + Gright.
 
-     @param T                   sample period T = 1/fs as needed to adapt
+     @param sampleRate          sample rate as needed to adapt
                                 capacitors/inductors
      @returns                   a double type port resistance of that element
                                 in Ohms
      */
-    virtual double calculateUpRes( double T );
+    virtual double calculateUpRes( double sampleRate );
 
     //----------------------------------------------------------------------
     /**
@@ -1190,12 +1184,12 @@ public:
      port resistance of the node to fulfill termination according to
      the inverters adaptation law Rup = Rchild.
 
-     @param T                   sample period T = 1/fs as needed to adapt
+     @param sampleRate          sample rate as needed to adapt
                                 capacitors/inductors
      @returns                   a double type port resistance of that element
                                 in Ohms
      */
-    virtual double calculateUpRes( double T );
+    virtual double calculateUpRes( double sampleRate );
 
     //----------------------------------------------------------------------
     /**
@@ -1280,10 +1274,10 @@ public:
      Creates a capacitor with capacitance C.
 
      @param C                  physical capacitance of the component in Farads
-     @param T                  sample period T = 1/fs in seconds
+     @param sampleRate         sample rate in Hertz
      */
     wdfTerminatedCap( double C,
-                      double T );
+                      double sampleRate );
 
     //----------------------------------------------------------------------
     /**
@@ -1291,14 +1285,14 @@ public:
 
      This function is called from adaptPorts(). It returns the upfacing
      port resistance of the node to fulfill termination according to
-     the capacitors adaptation law Rup = T / ( 2.0 * C ).
+     the capacitors adaptation law Rup = 1 / ( 2.0 * sampleRate * C ).
 
-     @param T                   sample period T = 1/fs in seconds as needed to
+     @param sampleRate          sample rate in Hertz as needed to
                                 adapt the capacitor
      @returns                   a double type port resistance of that element
                                 in Ohms
      */
-    virtual double calculateUpRes( double T );
+    virtual double calculateUpRes( double sampleRate );
 
     //----------------------------------------------------------------------
     /**
@@ -1339,9 +1333,9 @@ public:
      */
     double C;
     /**
-     Sample period in seconds
+     Sample rate in Hertz
      */
-    double T;
+    double sampleRate;
     /**
      One sample delay element
      */
@@ -1360,10 +1354,10 @@ public:
      Creates an inductor with inductance L.
 
      @param L                  physical inductance of the component in Henry
-     @param T                  sample period T = 1/fs in seconds
+     @param sampleRate         sample rate in Hertz
      */
     wdfTerminatedInd( double L,
-                      double T );
+                      double sampleRate );
 
     //----------------------------------------------------------------------
     /**
@@ -1371,14 +1365,14 @@ public:
 
      This function is called from adaptPorts(). It returns the upfacing
      port resistance of the node to fulfill termination according to
-     the inverters adaptation law Rup = R = ( 2.0 * L ) / T.
+     the inverters adaptation law Rup = R = 2.0 * sampleRate L.
 
-     @param T                   sample period T = 1/fs in seconds as needed to
+     @param sampleRate          sample rate in Hertz as needed to
                                 adapt the capacitor
      @returns                   a double type port resistance of that element
                                 in Ohms
      */
-    virtual double calculateUpRes( double T );
+    virtual double calculateUpRes( double sampleRate );
 
     //----------------------------------------------------------------------
     /**
@@ -1420,9 +1414,9 @@ public:
      */
     double L;
     /**
-     Sample period in seconds
+     Sample rate in Hertz
      */
-    double T;
+    double sampleRate;
     /**
      One sample delay element
      */
@@ -1452,12 +1446,12 @@ public:
      port resistance of the node to fulfill termination according to
      the resistors adaptation law Rup = R.
 
-     @param T                   sample period T = 1/fs in seconds as needed to
+     @param sampleRate          sample rate in Hertz as needed to
                                 adapt the capacitor
      @returns                   a double type port resistance of that element
                                 in Ohms
      */
-    virtual double calculateUpRes( double T );
+    virtual double calculateUpRes( double sampleRate );
 
     //----------------------------------------------------------------------
     /**
@@ -1524,12 +1518,12 @@ public:
      port resistance of the node to fulfill termination according to
      the adaptation law Rup = Rser.
 
-     @param T                   sample period T = 1/fs in seconds as needed to
+     @param sampleRate          sample rate in Hertz as needed to
                                 adapt the capacitor
      @returns                   a double type port resistance of that element
                                 in Ohms
      */
-    virtual double calculateUpRes( double T );
+    virtual double calculateUpRes( double sampleRate );
 
     //----------------------------------------------------------------------
     /**
@@ -1601,12 +1595,12 @@ public:
      port resistance of the node to fulfill termination according to
      the adaptation law Rup = Rpar.
 
-     @param T                   sample period T = 1/fs in seconds as needed to
+     @param sampleRate          sample rate in Hertz as needed to
                                 adapt the element
      @returns                   a double type port resistance of that element
                                 in Ohms
      */
-    virtual double calculateUpRes( double T );
+    virtual double calculateUpRes( double sampleRate );
 
     //----------------------------------------------------------------------
     /**
@@ -1806,9 +1800,9 @@ class wdfUnterminatedCap : public wdfRootNode {
 protected:
     //----------------------------------------------------------------------
     /**
-     Sample period in seconds
+     Sample rate in Hertz
     */
-    double T;
+    double sampleRate;
     /**
      Place to store the previous incident wave component.
     */
@@ -1833,10 +1827,10 @@ public:
      Creates an unadapted capacitor with capacitance C.
 
      @param C                  physical capacitance of the component in Farads
-     @param T                  sample period T = 1/fs in seconds
+     @param sampleRate         sample rate in Hertz
     */
     wdfUnterminatedCap( double C,
-                        double T );
+                        double sampleRate );
 
     //----------------------------------------------------------------------
     /**
@@ -1894,9 +1888,9 @@ class wdfUnterminatedInd : public wdfRootNode {
 protected:
     //----------------------------------------------------------------------
     /**
-     Sample period in seconds
+     Sample rate in Hertz
     */
-    double T;
+    double sampleRate;
     /**
      Place to store the previous incident wave component.
     */
@@ -1921,10 +1915,10 @@ public:
      Creates an unadapted inductor with capacitance L.
 
      @param L                  physical inductance of the component in Henry
-     @param T                  sample period T = 1/fs in seconds
+     @param sampleRate         sample rate in Hertz
     */
     wdfUnterminatedInd( double L,
-                        double T );
+                        double sampleRate );
 
     //----------------------------------------------------------------------
     /**


### PR DESCRIPTION
It is redundant and unnecessary to keep track of both sample period and sample rate. Although the other way around is obviously also possible, here I have changed all references to sample period to sample rate.